### PR TITLE
Remove disclaimers and simplify replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,29 @@
-# Discord AI Reply Selfbot 🤖🔥
+# Discord AI Reply Selfbot
 
-An OpenAI-powered Discord selfbot that:
-- Replies to messages in a selected channel
-- Skips replies with blacklisted words
-- Has a cracked Gen-Z CS2 pro personality 🧠💣
-- Comes with a GUI config generator
+This project is a simple OpenAI powered selfbot that automatically replies to messages in a chosen Discord channel. It now aims to produce more natural, human-like responses.
 
 ---
 
-## ⚠️ Disclaimer
-This project uses `discord.py-self`, which **violates Discord Terms of Service**. It is **for educational and testing purposes only**. Use at your own risk with throwaway accounts.
+
+## Features
+
+- Generates short, friendly replies using GPT-4
+- Word blacklist to skip certain messages
+- GUI (`config_gui.py`) to create the `config.json` file
 
 ---
 
-## 🛠 Features
+## Getting Started
 
-- 🔥 Gen Z slang and cracked replies using GPT-4
-- 📱 GUI (`config_gui.py`) to set your token, server, channel, etc.
-- ⛔ Word blacklist filter
-- 🧠 Uses OpenAI ChatCompletion for replies
-
----
-
-## 🚀 Getting Started
-
-### 1. Install dependencies
-
-```bash
-pip install -r requirements.txt
+1. Install the dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the config generator and fill in your details:
+   ```bash
+   python config_gui.py
+   ```
+3. Start the selfbot:
+   ```bash
+   python selfbot.py
+   ```

--- a/selfbot.py
+++ b/selfbot.py
@@ -1,8 +1,6 @@
+import json
 import discord
 import openai
-import json
-import random
-import asyncio
 
 with open("config.json") as f:
     cfg = json.load(f)
@@ -15,44 +13,39 @@ BLACKLIST = cfg["blacklist"]
 
 openai.api_key = OPENAI_API_KEY
 
-
 client = discord.Client(self_bot=True)
 
-crazy_openers = [
-    "Bro I'm built diff 💀:",
-    "Yooo no cap this is wild af 👉😳:",
-    "Okay but hear me out 💡🔥:",
-    "Sigma take incoming 🚨:",
-    "Deadass? Lemme cook 👨‍🍳:"
-]
 
 @client.event
 async def on_ready():
-    print(f"[✅] Logged in as {client.user} — Ready to RIZZ up in CS2 style 💣")
+    print(f"[✅] Logged in as {client.user}")
 
-def is_blacklisted(text):
+def is_blacklisted(text: str) -> bool:
+    """Check if any blacklist word is present in the text."""
     return any(bad.lower() in text.lower() for bad in BLACKLIST)
 
-async def generate_reply(msg):
+async def generate_reply(msg: str) -> str:
     try:
         response = openai.ChatCompletion.create(
             model="gpt-4",
             messages=[
-                {"role": "system", "content": "You are a cracked Gen Z CS2 pro player who speaks in gamer slang and zoomer memes. Respond short, chaotic, but genius."},
-                {"role": "user", "content": msg}
+                {
+                    "role": "system",
+                    "content": "You are a helpful friend chatting naturally. Keep responses concise and human-like."
+                },
+                {"role": "user", "content": msg},
             ],
             max_tokens=120,
-            temperature=1
+            temperature=0.7,
         )
-        reply = response['choices'][0]['message']['content'].strip()
-        opener = random.choice(crazy_openers)
-        return f"{opener} {reply}"
-    except Exception as e:
-        print(f"[❌] Error: {e}")
-        return "Bro I'm lagging rn 😵, can't even reply..."
+        reply = response["choices"][0]["message"]["content"].strip()
+        return reply
+    except Exception as exc:
+        print(f"[❌] Error: {exc}")
+        return "Sorry, I couldn't come up with a reply."
 
 @client.event
-async def on_message(message):
+async def on_message(message: discord.Message):
     if message.author.id == client.user.id:
         return
     if message.guild is None or message.guild.id != GUILD_ID:
@@ -60,77 +53,7 @@ async def on_message(message):
     if message.channel.id != CHANNEL_ID:
         return
     if is_blacklisted(message.content):
-        print(f"[⚠️] Skipped message: blacklisted word found")
-        return
-
-    print(f"[📩] {message.author.display_name}: {message.content}")
-    reply = await generate_reply(message.content)
-    await message.channel.send(reply)
-
-client.run(TOKEN)
-import discord
-import openai
-import json
-import random
-import asyncio
-
-with open("config.json") as f:
-    cfg = json.load(f)
-
-TOKEN = cfg["token"]
-GUILD_ID = cfg["guild_id"]
-CHANNEL_ID = cfg["channel_id"]
-OPENAI_API_KEY = cfg["openai_key"]
-BLACKLIST = cfg["blacklist"]
-
-openai.api_key = OPENAI_API_KEY
-
-
-client = discord.Client(self_bot=True)
-
-crazy_openers = [
-    "Bro I'm built diff 💀:",
-    "Yooo no cap this is wild af 👉😳:",
-    "Okay but hear me out 💡🔥:",
-    "Sigma take incoming 🚨:",
-    "Deadass? Lemme cook 👨‍🍳:"
-]
-
-@client.event
-async def on_ready():
-    print(f"[✅] Logged in as {client.user} — Ready to RIZZ up in CS2 style 💣")
-
-def is_blacklisted(text):
-    return any(bad.lower() in text.lower() for bad in BLACKLIST)
-
-async def generate_reply(msg):
-    try:
-        response = openai.ChatCompletion.create(
-            model="gpt-4",
-            messages=[
-                {"role": "system", "content": "You are a cracked Gen Z CS2 pro player who speaks in gamer slang and zoomer memes. Respond short, chaotic, but genius."},
-                {"role": "user", "content": msg}
-            ],
-            max_tokens=120,
-            temperature=1
-        )
-        reply = response['choices'][0]['message']['content'].strip()
-        opener = random.choice(crazy_openers)
-        return f"{opener} {reply}"
-    except Exception as e:
-        print(f"[❌] Error: {e}")
-        return "Bro I'm lagging rn 😵, can't even reply..."
-
-@client.event
-async def on_message(message):
-    if message.author.id == client.user.id:
-        return
-    if message.guild is None or message.guild.id != GUILD_ID:
-        return
-    if message.channel.id != CHANNEL_ID:
-        return
-    if is_blacklisted(message.content):
-        print(f"[⚠️] Skipped message: blacklisted word found")
+        print("[⚠️] Skipped blacklisted message")
         return
 
     print(f"[📩] {message.author.display_name}: {message.content}")


### PR DESCRIPTION
## Summary
- remove TOS disclaimer from README
- simplify `generate_reply` to return natural text without openers

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile selfbot.py`
- `python -m py_compile config_gui.py`


------
https://chatgpt.com/codex/tasks/task_e_688bb12ec90883329ce97d87abd06d2c