### PR TITLE
Limit selfbot to one queued reply

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This project is a simple OpenAI powered selfbot that automatically replies to me
 - Generates short, friendly replies using GPT-4
 - Word blacklist to skip certain messages
 - Skips messages without real words (links or gibberish)
+- Handles a single queued reply at once to avoid floods
 - GUI (`config_gui.py`) to create the `config.json` file
 
 ---


### PR DESCRIPTION
## Summary
- limit reply queue to a single message
- start background task to process the queue
- mention single queued reply feature in README

## Testing
- `python -m py_compile selfbot.py`

------
https://chatgpt.com/codex/tasks/task_e_688bcb002b8c83329c4e9f581c8bc763