### PR TITLE
Ignore new messages when reply queue is full

### DIFF
--- a/selfbot.py
+++ b/selfbot.py
@@ -97,9 +97,7 @@ async def on_message(message: discord.Message):
 
     print(f"[📩] {message.author.display_name}: {message.content}")
     if message_queue.full():
-        try:
-            message_queue.get_nowait()
-        except asyncio.QueueEmpty:
-            pass
+        print("[⚠️] Queue full, ignoring new message")
+        return
     await message_queue.put(message)
 client.run(TOKEN)


### PR DESCRIPTION
## Summary
- only allow one message in the reply queue at a time
- skip incoming messages while waiting for the current reply

## Testing
- `python -m py_compile selfbot.py config_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_688bd5a92088833286ee0560c67238c6